### PR TITLE
Add code to fix lms_root_url issue by replacing it with localhost:18000

### DIFF
--- a/openedx_caliper_tracking/tests/tests.py
+++ b/openedx_caliper_tracking/tests/tests.py
@@ -54,20 +54,20 @@ class CaliperTransformationTestCase(TestCase):
                 TEST_DIR_PATH,
                 current_file
             )
+            with self.settings(LMS_ROOT_URL='http://localhost:18000'):
+                with open(input_file) as current, open(output_file) as expected:
+                    event = json.loads(current.read())
+                    expected_event = json.loads(expected.read())
 
-            with open(input_file) as current, open(output_file) as expected:
-                event = json.loads(current.read())
-                expected_event = json.loads(expected.read())
+                    expected_event.pop('id')
 
-                expected_event.pop('id')
+                    caliper_event = base_transformer(event)
+                    related_function = EVENT_MAPPING[event.get('event_type')]
+                    caliper_event = related_function(event, caliper_event)
 
-                caliper_event = base_transformer(event)
-                related_function = EVENT_MAPPING[event.get('event_type')]
-                caliper_event = related_function(event, caliper_event)
+                    caliper_event.pop('id')
 
-                caliper_event.pop('id')
-
-                self.assertDictEqual(caliper_event, expected_event)
+                    self.assertDictEqual(caliper_event, expected_event)
 
 
 class CaliperDeliveryTestCase(TestCase):


### PR DESCRIPTION
Currently, the success of our tests depends on the value of `LMS_ROOT_URL`. If its value is `http://localhost:18000`, our tests would pass but if it's not then our tests would fail as in our expected files we have hardcoded `http://localhost:18000`. 
The quick fix to this issue is to replace the value of `LMS_ROOT_URL` in the `transformed caliper event` just before the assertion we are doing in our test.
As we will do this only in tests so the other workflow will not be affected and our tests would pass too.