### PR TITLE
Add independent unit tests for caliper app

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,4 +2,5 @@ include LICENSE
 include README.rst
 include openedx_caliper_tracking/tests/current/*.json
 include openedx_caliper_tracking/tests/expected/*.json
+include openedx_caliper_tracking/tests/*.txt
 include openedx_caliper_tracking/templates/openedx_caliper_tracking/*.html

--- a/openedx_caliper_tracking/__init__.py
+++ b/openedx_caliper_tracking/__init__.py
@@ -17,3 +17,4 @@ if hasattr(django_settings, 'EVENT_TRACKING_BACKENDS'):
 
 if hasattr(django_settings, 'TRACKING_BACKENDS'):
     django_settings.TRACKING_BACKENDS = OPENEDX_CALIPER_TRACKING_BACKENDS
+

--- a/openedx_caliper_tracking/processor.py
+++ b/openedx_caliper_tracking/processor.py
@@ -4,12 +4,18 @@ import requests
 
 from django.conf import settings
 from requests.exceptions import ConnectionError
-from track.backends import BaseBackend
 
 from openedx_caliper_tracking.base_transformer import base_transformer, page_view_transformer
 from openedx_caliper_tracking.caliper_config import EVENT_MAPPING
 from openedx_caliper_tracking.loggers import get_caliper_logger
 from openedx_caliper_tracking.tasks import deliver_caliper_event_to_kafka
+
+try:
+    # if app is running in edx-platfrom get BaseBackend from edx codebase
+    from track.backends import BaseBackend
+except (NameError, ImportError):
+    # if app is running locally for testing use Testing Backend
+    from openedx_caliper_tracking.tests.testing_backend import BaseBackend
 
 
 LOGGER = logging.getLogger(__name__)

--- a/openedx_caliper_tracking/tests/current/book.json
+++ b/openedx_caliper_tracking/tests/current/book.json
@@ -1,21 +1,27 @@
 {
-    "username": "staff",
-    "event_source": "browser",
-    "name": "book",
-    "accept_language": "en-US,en;q=0.9",
-    "time": "2018-10-19T07:49:07.392782+00:00",
-    "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
-    "page": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/pdfbook/0/?viewer=true&file=/assets/courseware/v1/55969d87f0409b18ed8d979465e80f1a/asset-v1:edX+DemoX+Demo_Course+type@asset+block/gazatte_11th_2018.pdf#zoom=page-fit&disableRange=true",
-    "host": "8433fad63981",
-    "session": "1e2bcef58672f0195f63d9e2f0736a7c",
-    "referer": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/pdfbook/0/?viewer=true&file=/assets/courseware/v1/55969d87f0409b18ed8d979465e80f1a/asset-v1:edX+DemoX+Demo_Course+type@asset+block/gazatte_11th_2018.pdf",
-    "context": {
-        "user_id": 8,
-        "org_id": "edX",
-        "course_id": "course-v1:edX+DemoX+Demo_Course",
-        "path": "/event"
+    "username":"honor",
+    "event_source":"server",
+    "name":"edx.bookmark.listed",
+    "accept_language":"en-US,en;q=0.9,ur-PK;q=0.8,ur;q=0.7",
+    "time":"2018-10-16T14:23:24.785148+00:00",
+    "agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+    "page":null,
+    "host":"747befdb3d9d",
+    "session":"87d4e5619e69f6e03cfa8d8ded61d197",
+    "referer":"http://localhost:18000/courses/course-v1:edx+cs-101+2018/bookmarks/",
+    "context":{
+       "user_id":6,
+       "org_id":"",
+       "course_id":"",
+       "path":"/api/bookmarks/v1/bookmarks/"
     },
-    "ip": "172.18.0.1",
-    "event": "{\"chapter\": \"/assets/courseware/v1/55969d87f0409b18ed8d979465e80f1a/asset-v1:edX+DemoX+Demo_Course+type@asset+block/gazatte_11th_2018.pdf\", \"old\": 1, \"type\": \"gotopage\", \"name\": \"textbook.pdf.page.loaded\", \"new\": 2}",
-    "event_type": "book"
-}
+    "ip":"172.18.0.1",
+    "event":{
+       "course_id":"course-v1:edx+cs-101+2018",
+       "page_number":1,
+       "bookmarks_count":1,
+       "page_size":10,
+       "list_type":"per_course"
+    },
+    "event_type":"edx.bookmark.listed"
+ }

--- a/openedx_caliper_tracking/tests/current/edx.certificate.created.json
+++ b/openedx_caliper_tracking/tests/current/edx.certificate.created.json
@@ -6,15 +6,15 @@
     "course_user_tags": {},
     "org_id": "edx",
     "path": "/courses/course-v1:edx+cs-101+2018/generate_user_cert",
-    "user_id": 2
+    "user_id": 8
   },
   "event": {
     "certificate_id": "d4cd91fcd49f42fe97db585ed7e8b459",
-    "certificate_url": "/certificates/user/2/course/course-v1:edx+cs-101+2018",
+    "certificate_url": "/certificates/user/8/course/course-v1:edx+cs-101+2018",
     "course_id": "course-v1:edx+cs-101+2018",
     "enrollment_mode": "verified",
     "generation_mode": "self",
-    "user_id": 2
+    "user_id": 8
   },
   "event_source": "server",
   "event_type": "edx.certificate.created",

--- a/openedx_caliper_tracking/tests/current/edx.certificate.evidence_visited.json
+++ b/openedx_caliper_tracking/tests/current/edx.certificate.evidence_visited.json
@@ -13,7 +13,7 @@
       "user_id":null,
       "org_id":"pucit",
       "course_id":"course-v1:pucit+cs_08+2019_F",
-      "path":"/certificates/user/8/course/course-v1:pucit+cs_08+2019_F"
+      "path":"/certificates/user/8/course/course-v1:edx+cs-101+2018"
    },
    "ip":"172.18.0.1",
    "event":{
@@ -22,7 +22,7 @@
       "user_id":8,
       "course_id":"course-v1:pucit+cs_08+2019_F",
       "certificate_id":"402fb5284c2b413eafa8f569867562a2",
-      "certificate_url":"/certificates/user/8/course/course-v1:pucit+cs_08+2019_F"
+      "certificate_url":"/certificates/user/8/course/course-v1:edx+cs-101+2018"
    },
    "event_type":"edx.certificate.evidence_visited"
 }

--- a/openedx_caliper_tracking/tests/current/edx.certificate.shared.json
+++ b/openedx_caliper_tracking/tests/current/edx.certificate.shared.json
@@ -5,10 +5,10 @@
   "accept_language": "en-US,en;q=0.9",
   "time": "2019-01-09T09:57:44.758959+00:00",
   "agent": "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.80 Safari/537.36",
-  "page": "http://localhost:18000/certificates/user/8/course/course-v1:pucit+cs_08+2019_F",
+  "page": "http://localhost:18000/certificates/user/8/course/course-v1:edx+cs-101+2018",
   "host": "8c3b43aa7b1b",
   "session": "51ec4c05447ef4a00a9427f588c3e840",
-  "referer": "http://localhost:18000/certificates/user/8/course/course-v1:pucit+cs_08+2019_F",
+  "referer": "http://localhost:18000/certificates/user/8/course/course-v1:edx+cs-101+2018",
   "context": {
     "user_id": 8,
     "org_id": "",
@@ -16,6 +16,6 @@
     "path": "/event"
   },
   "ip": "172.18.0.1",
-  "event": "{\"enrollment_mode\": \"verified\", \"user_id\": \"8\", \"certificate_id\": \"402fb5284c2b413eafa8f569867562a2\", \"certificate_url\": \"http://localhost:18000/certificates/user/8/course/course-v1:pucit+cs_08+2019_F\", \"social_network\": \"LinkedIn\", \"course_id\": \"course-v1:pucit+cs_08+2019_F\"}",
+"event": "{\"enrollment_mode\": \"verified\", \"user_id\": \"8\", \"certificate_id\": \"402fb5284c2b413eafa8f569867562a2\", \"certificate_url\": \"http://localhost:18000/certificates/user/8/course/course-v1:edx+cs-101+2018\", \"social_network\": \"LinkedIn\", \"course_id\": \"course-v1:edx+cs-101+2018\"}",
   "event_type": "edx.certificate.shared"
 }

--- a/openedx_caliper_tracking/tests/expected/book.json
+++ b/openedx_caliper_tracking/tests/expected/book.json
@@ -2,42 +2,41 @@
     "@context": "http://purl.imsglobal.org/ctx/caliper/v1p1",
     "action": "NavigatedTo",
     "actor": {
-        "id": "http://localhost:18000/u/staff",
-        "name": "staff",
-        "type": "Person"
+      "id": "http://localhost:18000/u/honor",
+      "name": "honor",
+      "type": "Person"
     },
-    "eventTime": "2018-10-19T07:49:07.392Z",
+    "eventTime": "2018-10-16T14:23:24.785Z",
     "extensions": {
-        "extra_fields": {
-            "accept_language": "en-US,en;q=0.9",
-            "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
-            "course_id": "course-v1:edX+DemoX+Demo_Course",
-            "event_source": "browser",
-            "event_type": "book",
-            "host": "8433fad63981",
-            "ip": "172.18.0.1",
-            "org_id": "edX",
-            "page": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/pdfbook/0/?viewer=true&file=/assets/courseware/v1/55969d87f0409b18ed8d979465e80f1a/asset-v1:edX+DemoX+Demo_Course+type@asset+block/gazatte_11th_2018.pdf#zoom=page-fit&disableRange=true",
-            "path": "/event",
-            "session": "1e2bcef58672f0195f63d9e2f0736a7c",
-            "user_id": 8
-        }
+      "extra_fields": {
+        "accept_language": "en-US,en;q=0.9,ur-PK;q=0.8,ur;q=0.7",
+        "agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+        "event_source": "server",
+        "event_type": "edx.bookmark.listed",
+        "host": "747befdb3d9d",
+        "ip": "172.18.0.1",
+        "org_id": "",
+        "page": null,
+        "path": "/api/bookmarks/v1/bookmarks/",
+        "session": "87d4e5619e69f6e03cfa8d8ded61d197",
+        "user_id": 6
+      }
     },
-    "id": "urn:uuid:4a725288-39af-4735-a3b4-21e2c002ac38",
+    "id": "urn:uuid:d4618c23-d612-4709-8d9a-478d87808067",
     "object": {
-        "extensions": {
-            "chapter": "/assets/courseware/v1/55969d87f0409b18ed8d979465e80f1a/asset-v1:edX+DemoX+Demo_Course+type@asset+block/gazatte_11th_2018.pdf",
-            "name": "textbook.pdf.page.loaded",
-            "new": 2,
-            "old": 1,
-            "type": "gotopage"
-        },
-        "id": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/pdfbook/0/?viewer=true&file=/assets/courseware/v1/55969d87f0409b18ed8d979465e80f1a/asset-v1:edX+DemoX+Demo_Course+type@asset+block/gazatte_11th_2018.pdf",
-        "type": "Document"
+      "id": "http://localhost:18000/courses/course-v1:edx+cs-101+2018/bookmarks/",
+      "type": "WebPage",
+      "extensions": {
+        "bookmarks_count": 1,
+        "course_id": "course-v1:edx+cs-101+2018",
+        "list_type": "per_course",
+        "page_number": 1,
+        "page_size": 10
+      }
     },
     "referrer": {
-        "id": "http://localhost:18000/courses/course-v1:edX+DemoX+Demo_Course/pdfbook/0/?viewer=true&file=/assets/courseware/v1/55969d87f0409b18ed8d979465e80f1a/asset-v1:edX+DemoX+Demo_Course+type@asset+block/gazatte_11th_2018.pdf",
-        "type": "WebPage"
+      "id": "http://localhost:18000/courses/course-v1:edx+cs-101+2018/bookmarks/",
+      "type": "WebPage"
     },
     "type": "NavigationEvent"
-}
+  }

--- a/openedx_caliper_tracking/tests/expected/edx.certificate.created.json
+++ b/openedx_caliper_tracking/tests/expected/edx.certificate.created.json
@@ -20,7 +20,7 @@
       "page": null,
       "path": "/courses/course-v1:edx+cs-101+2018/generate_user_cert",
       "session": "4fc32b1ca8d4fc18402c4c41434a178a",
-      "user_id": 2,
+      "user_id": 8,
       "username": "honor"
     }
   },
@@ -28,13 +28,13 @@
   "object": {
     "extensions": {
       "certificate_id": "d4cd91fcd49f42fe97db585ed7e8b459",
-      "certificate_url": "/certificates/user/2/course/course-v1:edx+cs-101+2018",
+      "certificate_url": "/certificates/user/8/course/course-v1:edx+cs-101+2018",
       "course_id": "course-v1:edx+cs-101+2018",
       "enrollment_mode": "verified",
       "generation_mode": "self",
-      "user_id": 2
+      "user_id": 8
     },
-    "id": "http://localhost:18000/certificates/user/2/course/course-v1:edx+cs-101+2018",
+    "id": "http://localhost:18000/certificates/user/8/course/course-v1:edx+cs-101+2018",
     "type": "Document"
   },
   "referrer": {

--- a/openedx_caliper_tracking/tests/expected/edx.certificate.evidence_visited.json
+++ b/openedx_caliper_tracking/tests/expected/edx.certificate.evidence_visited.json
@@ -20,7 +20,7 @@
       "org_id":"pucit",
       "referer":"",
       "course_id":"course-v1:pucit+cs_08+2019_F",
-      "path":"/certificates/user/8/course/course-v1:pucit+cs_08+2019_F",
+      "path":"/certificates/user/8/course/course-v1:edx+cs-101+2018",
       "username":""
     }
   },
@@ -32,9 +32,9 @@
       "user_id":8,
       "course_id":"course-v1:pucit+cs_08+2019_F",
       "certificate_id":"402fb5284c2b413eafa8f569867562a2",
-      "certificate_url":"/certificates/user/8/course/course-v1:pucit+cs_08+2019_F"
+      "certificate_url":"/certificates/user/8/course/course-v1:edx+cs-101+2018"
     },
-    "id": "http://localhost:18000/certificates/user/8/course/course-v1:pucit+cs_08+2019_F",
+    "id": "http://localhost:18000/certificates/user/8/course/course-v1:edx+cs-101+2018",
     "type": "Document"
   },
   "type": "Event"

--- a/openedx_caliper_tracking/tests/expected/edx.certificate.shared.json
+++ b/openedx_caliper_tracking/tests/expected/edx.certificate.shared.json
@@ -16,7 +16,7 @@
       "host": "8c3b43aa7b1b",
       "ip": "172.18.0.1",
       "org_id": "",
-      "page": "http://localhost:18000/certificates/user/8/course/course-v1:pucit+cs_08+2019_F",
+      "page": "http://localhost:18000/certificates/user/8/course/course-v1:edx+cs-101+2018",
       "path": "/event",
       "session": "51ec4c05447ef4a00a9427f588c3e840",
       "user_id": 8
@@ -26,17 +26,17 @@
   "object": {
     "extensions": {
       "certificate_id": "402fb5284c2b413eafa8f569867562a2",
-      "certificate_url": "http://localhost:18000/certificates/user/8/course/course-v1:pucit+cs_08+2019_F",
-      "course_id": "course-v1:pucit+cs_08+2019_F",
+      "certificate_url": "http://localhost:18000/certificates/user/8/course/course-v1:edx+cs-101+2018",
+      "course_id": "course-v1:edx+cs-101+2018",
       "enrollment_mode": "verified",
       "social_network": "LinkedIn",
       "user_id": "8"
     },
-    "id": "http://localhost:18000/certificates/user/8/course/course-v1:pucit+cs_08+2019_F",
+    "id": "http://localhost:18000/certificates/user/8/course/course-v1:edx+cs-101+2018",
     "type": "Document"
   },
   "referrer": {
-    "id": "http://localhost:18000/certificates/user/8/course/course-v1:pucit+cs_08+2019_F",
+    "id": "http://localhost:18000/certificates/user/8/course/course-v1:edx+cs-101+2018",
     "type": "WebPage"
   },
   "type": "Event"

--- a/openedx_caliper_tracking/tests/factories.py
+++ b/openedx_caliper_tracking/tests/factories.py
@@ -1,0 +1,20 @@
+import factory
+from django.contrib.auth.models import User
+from factory.django import DjangoModelFactory
+
+USER_PASSWORD = 'TEST_PASSOWRD'
+
+
+class UserFactory(DjangoModelFactory):
+    """
+    Crete user with the given credentials.
+    """
+    class Meta(object):
+        model = User
+        django_get_or_create = ('email', 'username')
+
+    username = factory.Sequence(u'robot{0}'.format)
+    email = factory.LazyAttribute(lambda obj: '%s@example.com' % obj.username)
+    password = factory.PostGenerationMethodCall('set_password', USER_PASSWORD)
+    is_active = True
+    is_superuser = False

--- a/openedx_caliper_tracking/tests/local_test_script.sh
+++ b/openedx_caliper_tracking/tests/local_test_script.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# This script file is to run the caliper app tests locally.
+
+if [ "$(ls | grep -w openedx-caliper-tracking)" != "" ]; then
+    FOLDER_NAME="caliper_app_testing"
+    PROJECT_NAME="caliper_project"
+    rm -rf $FOLDER_NAME
+    mkdir $FOLDER_NAME
+    cd $FOLDER_NAME
+
+    printf "\n\n\n=========================================\n"
+    printf "Making and Activating Virtual Environment"
+    printf "\n=========================================\n"
+    virtualenv venv --python=python2.7
+    source venv/bin/activate
+
+    printf "\n\n\n=======================\n"
+    printf "Installing Dependencies"
+    printf "\n=======================\n"
+    pip install  ../openedx-caliper-tracking
+    pip install -r venv/lib/python2.7/site-packages/openedx_caliper_tracking/tests/test_requirements.txt
+
+    printf "\n\n\n=======================\n"
+    printf "Creating Django Project"
+    printf "\n=======================\n"
+    django-admin.py startproject $PROJECT_NAME
+    sudo apt-get install sed
+    cd $PROJECT_NAME/$PROJECT_NAME/
+    # Append 'openedx_caliper_tracking' in INSTALLED_APPS list of settings.py
+    sed "/'django.contrib.staticfiles',/a 'openedx_caliper_tracking'" settings.py > temp_settings.py
+    rm settings.py
+    mv temp_settings.py settings.py
+    cd ..
+
+    printf "\n\n\n=====================\n"
+    printf "Running Caliper Tests"
+    printf "\n=====================\n"
+    coverage run --source='openedx_caliper_tracking' manage.py test openedx_caliper_tracking
+    coverage report --omit='*tests*, *pavement.py*, *__init__.py*'
+    deactivate
+    cd ../..
+    rm -rf $FOLDER_NAME
+else
+    echo "Your current directory doesn't contain the package named openedx-caliper-tracking."
+fi

--- a/openedx_caliper_tracking/tests/test_caliper_delivery.py
+++ b/openedx_caliper_tracking/tests/test_caliper_delivery.py
@@ -5,7 +5,6 @@ application logs delivery to Rest API.
 import json
 
 import mock
-from django.conf import settings
 from django.test import TestCase, override_settings
 
 from openedx_caliper_tracking.processor import CaliperProcessor
@@ -25,11 +24,14 @@ class CaliperDeliveryTestCase(TestCase):
         )
         with open(input_file) as current:
             self.event = json.loads(current.read())
+        patcher = mock.patch('openedx_caliper_tracking.processor.deliver_caliper_event')
+        self.delivery_mock = patcher.start()
+        self.addCleanup(patcher.stop)
 
-    @mock.patch(
-        'openedx_caliper_tracking.processor.deliver_caliper_event'
+    @override_settings(
+        FEATURES={}
     )
-    def test_event_is_not_called_without_settings(self, delivery_mock):
+    def test_event_is_not_called_without_settings(self):
         """
         Test that API call shouldn't fire if the following settings
 
@@ -39,45 +41,30 @@ class CaliperDeliveryTestCase(TestCase):
 
         are not given.
         """
-        if settings.FEATURES.get('ENABLE_CALIPER_EVENTS_DELIVERY'):
-            settings.FEATURES.pop('ENABLE_CALIPER_EVENTS_DELIVERY')
-
-        if hasattr(settings, 'CALIPER_DELIVERY_ENDPOINT'):
-            del settings.CALIPER_DELIVERY_ENDPOINT
-
-        if hasattr(settings, 'CALIPER_DELIVERY_AUTH_TOKEN'):
-            del settings.CALIPER_DELIVERY_AUTH_TOKEN
-
         CaliperProcessor().__call__(self.event)
-        self.assertFalse(delivery_mock.called)
+        self.assertFalse(self.delivery_mock.called)
 
-    @mock.patch(
-        'openedx_caliper_tracking.processor.deliver_caliper_event'
-    )
     @override_settings(
         CALIPER_DELIVERY_ENDPOINT='http://localhost:3000',
         CALIPER_DELIVERY_AUTH_TOKEN='test_auth_token',
         FEATURES={'ENABLE_CALIPER_EVENTS_DELIVERY': False}
     )
-    def test_event_is_not_called_with_unset_delivery_flag(self, delivery_mock):
+    def test_event_is_not_called_with_unset_delivery_flag(self):
         """
         Test that API call shouldn't fire if the feature flag ENABLE_CALIPER_EVENTS_DELIVERY is not set.
         """
         CaliperProcessor().__call__(self.event)
-        self.assertFalse(delivery_mock.called)
+        self.assertFalse(self.delivery_mock.called)
 
-    @mock.patch(
-        'openedx_caliper_tracking.processor.deliver_caliper_event',
-        autospec=True
-    )
     @override_settings(
+        LMS_ROOT_URL='http://localhost:3000',
         CALIPER_DELIVERY_ENDPOINT='http://localhost:3000',
         CALIPER_DELIVERY_AUTH_TOKEN='test_auth_token',
         FEATURES={'ENABLE_CALIPER_EVENTS_DELIVERY': True}
     )
-    def test_event_is_called_with_settings(self, delivery_mock):
+    def test_event_is_called_with_settings(self):
         """
         Test that  caliper event is delivered with all required settings given.
         """
         CaliperProcessor().__call__(self.event)
-        self.assertTrue(delivery_mock.called)
+        self.assertTrue(self.delivery_mock.called)

--- a/openedx_caliper_tracking/tests/test_caliper_kafka.py
+++ b/openedx_caliper_tracking/tests/test_caliper_kafka.py
@@ -5,11 +5,13 @@ application logs delivery to Kafka.
 import json
 
 import mock
-from django.conf import settings
 from django.test import TestCase, override_settings
 from kafka.errors import KafkaError
+
 from openedx_caliper_tracking.processor import CaliperProcessor
-from openedx_caliper_tracking.tasks import _host_not_found
+from openedx_caliper_tracking.tasks import (host_not_found, deliver_caliper_event_to_kafka,
+                                            sent_kafka_failure_email, send_system_recovery_email,
+                                            HOST_ERROR_CACHE_KEY, EMAIL_DELIVERY_CACHE_KEY)
 from openedx_caliper_tracking.tests import TEST_DIR_PATH
 
 
@@ -24,6 +26,36 @@ class CaliperKafkaTestCase(TestCase):
             self.event = json.loads(current.read())
 
     @mock.patch(
+        'openedx_caliper_tracking.processor.deliver_caliper_event_to_kafka.delay',
+        autospec=True,
+    )
+    @override_settings(
+        LMS_ROOT_URL='https://localhost:18000',
+        CALIPER_KAFKA_SETTINGS={
+            'END_POINT': 'http://localhost:9092',
+            'TOPIC_NAME': 'dummy topic',
+            'ERROR_REPORT_EMAIL': 'dummy@example.com',
+            'MAXIMUM_RETRIES': 3
+        },
+        FEATURES={'ENABLE_KAFKA_FOR_CALIPER': True}
+    )
+    def test_caliper_event_is_delivered_to_kafka_without_error_using_celery(self, delivery_mock):
+        """
+        Test that  caliper event is delivered with
+        all required settings given using celery.
+        """
+        CaliperProcessor().__call__(self.event)
+        self.assertTrue(delivery_mock.called)
+
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.LOGGER',
+        autospec=True,
+    )
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.sent_kafka_failure_email.delay',
+        autospec=True
+    )
+    @mock.patch(
         'openedx_caliper_tracking.tasks.KafkaProducer',
         autospec=True
     )
@@ -34,125 +66,278 @@ class CaliperKafkaTestCase(TestCase):
             'ERROR_REPORT_EMAIL': 'dummy@example.com',
             'MAXIMUM_RETRIES': 3
         },
-        FEATURES={'ENABLE_KAFKA_FOR_CALIPER': True}
     )
-    def test_caliper_event_is_delivered_to_kafka_without_error(self, producer_mock):
+    def test_deliver_caliper_event_to_kafka_without_using_celery_without_error(self, producer_mock,
+                                                                               sent_email_mock, logger_mock):
         """
-        Test that  caliper event is delivered with all required settings given.
+        Test that  caliper event is delivered with all
+        required settings given without using celery and any error.
         """
-        CaliperProcessor().__call__(self.event)
+        deliver_caliper_event_to_kafka({}, 'book')
         self.assertTrue(producer_mock.called)
+        self.assertFalse(sent_email_mock.called)
+        self.assertFalse(logger_mock.error.called)
+        logger_mock.info.assert_called_with('Logs Delivered Successfully: Event (book) has been successfully'
+                                            ' sent to kafka (http://localhost:9092).')
 
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.cache.get',
+        autospec=True,
+        side_effect=lambda CACHE_KEY: {HOST_ERROR_CACHE_KEY: False, EMAIL_DELIVERY_CACHE_KEY: True}[CACHE_KEY]
+    )
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.send_system_recovery_email.delay',
+        autospec=True,
+    )
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.LOGGER',
+        autospec=True,
+    )
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.sent_kafka_failure_email.delay',
+        autospec=True
+    )
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.KafkaProducer',
+        autospec=True
+    )
+    @override_settings(
+        CALIPER_KAFKA_SETTINGS={
+            'END_POINT': 'http://localhost:9092',
+            'TOPIC_NAME': 'dummy topic',
+            'ERROR_REPORT_EMAIL': 'dummy@example.com',
+            'MAXIMUM_RETRIES': 3
+        },
+    )
+    def test_deliver_caliper_event_to_kafka_without_celery_without_error_with_system_recovered(self, producer_mock,
+                                                                                               sent_email_mock,
+                                                                                               logger_mock,
+                                                                                               recovery_mail_mock,
+                                                                                               cache_mock):
+        """
+        Test that  caliper event is delivered with all required
+        settings given without using celery and any error.
+        """
+        deliver_caliper_event_to_kafka({}, 'book')
+        self.assertTrue(producer_mock.called)
+        self.assertFalse(sent_email_mock.called)
+        self.assertFalse(logger_mock.error.called)
+        self.assertTrue(recovery_mail_mock.called)
+        self.assertTrue(cache_mock.called)
+        logger_mock.info.assert_called_with('Logs Delivered Successfully: Event (book) has been successfully'
+                                            ' sent to kafka (http://localhost:9092).')
+
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.cache.get',
+        autospec=True,
+        return_value=True
+    )
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.KafkaProducer',
+        autospec=True
+    )
+    @override_settings(
+        CALIPER_KAFKA_SETTINGS={
+            'END_POINT': 'http://localhost:9092',
+            'TOPIC_NAME': 'dummy topic',
+            'ERROR_REPORT_EMAIL': 'dummy@example.com',
+            'MAXIMUM_RETRIES': 3
+        },
+    )
+    def test_deliver_caliper_event_to_kafka_without_celery_with_host_not_found_error_already_occurred(self,
+                                                                                                      producer_mock,
+                                                                                                      cache_mock):
+        deliver_caliper_event_to_kafka({}, 'book')
+        self.assertFalse(producer_mock.called)
+        cache_mock.assert_called_with(HOST_ERROR_CACHE_KEY)
+
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.deliver_caliper_event_to_kafka.retry',
+        autospec=True
+    )
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.LOGGER',
+        autospec=True,
+    )
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.sent_kafka_failure_email.delay',
+        autospec=True
+    )
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.KafkaProducer',
+        autospec=True,
+        side_effect=KafkaError
+    )
+    @override_settings(
+        CALIPER_KAFKA_SETTINGS={
+            'END_POINT': 'http://localhost:9092',
+            'TOPIC_NAME': 'dummy topic',
+            'ERROR_REPORT_EMAIL': 'dummy@example.com',
+            'MAXIMUM_RETRIES': 3
+        }
+    )
+    def test_deliver_caliper_event_to_kafka_without_celery_with_error_with_retry(self, producer_mock, sent_email_mock,
+                                                                                 logger_mock, retry_mock):
+        """
+        Test that caliper event is not delivered to kafka
+        when error is occurred and retry code is executed.
+        """
+        deliver_caliper_event_to_kafka({}, 'book')
+        self.assertTrue(producer_mock.called)
+        self.assertFalse(sent_email_mock.called)
+        logger_mock.error.assert_called_with('Logs Delivery Failed: Could not deliver event (book) to kafka'
+                                             ' (http://localhost:9092) because of KafkaError.')
+        self.assertTrue(retry_mock.called)
+
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.LOGGER',
+        autospec=True,
+    )
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.sent_kafka_failure_email.delay',
+        autospec=True
+    )
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.KafkaProducer',
+        autospec=True,
+        side_effect=KafkaError
+    )
+    @override_settings(
+        CALIPER_KAFKA_SETTINGS={
+            'END_POINT': 'http://localhost:9092',
+            'TOPIC_NAME': 'dummy topic',
+            'ERROR_REPORT_EMAIL': 'dummy@example.com',
+            'MAXIMUM_RETRIES': 0
+        }
+    )
+    def test_deliver_caliper_event_to_kafka_without_celery_with_error_without_retry(self, producer_mock,
+                                                                                    sent_email_mock, logger_mock):
+        """
+        Test that caliper event is not delivered to kafka when error is occurred
+        and at last retry failure email task is called.
+        """
+        deliver_caliper_event_to_kafka({}, 'book')
+        self.assertTrue(producer_mock.called)
+        self.assertTrue(sent_email_mock.called)
+        logger_mock.error.assert_called_with('Logs Delivery Failed: Could not deliver event (book) to kafka'
+                                             ' (http://localhost:9092) because of KafkaError.')
+
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.sent_kafka_failure_email.delay',
+        autospec=True,
+    )
+    def test_ifhost_not_found_error(self, sent_email_mock):
+        host_not_found(mock.MagicMock(), self.event, 'book')
+        self.assertTrue(sent_email_mock.called)
+
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.LOGGER',
+        autospec=True,
+    )
     @mock.patch(
         'openedx_caliper_tracking.tasks.send_notification',
-        autospec=True
-    )
-    @mock.patch(
-        'openedx_caliper_tracking.tasks.KafkaProducer',
+        autospec=True,
+        return_value=True
     )
     @override_settings(
         CALIPER_KAFKA_SETTINGS={
-            'END_POINT': 'http://localhost:9092',
-            'TOPIC_NAME': 'dummy topic',
             'ERROR_REPORT_EMAIL': 'dummy@example.com',
-            'MAXIMUM_RETRIES': 3
-        },
-        FEATURES={'ENABLE_KAFKA_FOR_CALIPER': True}
+        }
     )
-    def test_caliper_event_delivery_retries_if_kafka_error_occurs(self, producer_mock, send_email_mock):
+    def test_sent_kafka_failure_email_with_success(self, send_notification_mock, logger_mock):
         """
-        Test that in case of kafka error, task retires as per max retries given in the settings.
-        Test that delivery failure email report is sent if retries don't come fruitful.
+        Test that kafka failure email is sent successfully.
         """
-        producer_mock.side_effect = KafkaError
-        CaliperProcessor().__call__(self.event)
-        self.assertEqual(producer_mock.call_count, settings.CALIPER_KAFKA_SETTINGS.get('MAXIMUM_RETRIES') + 1)
-        self.assertTrue(producer_mock.called)
-        self.assertTrue(send_email_mock.called)
+        sent_kafka_failure_email('Dummy Error')
+        self.assertTrue(send_notification_mock.called)
+        logger_mock.info.assert_called_with('Email Sent Successfully: Events delivery failure report'
+                                            ' sent to dummy@example.com.')
 
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.LOGGER',
+        autospec=True,
+    )
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.cache.get',
+        autospec=True,
+        return_value=True
+    )
+    @override_settings(
+        CALIPER_KAFKA_SETTINGS={
+            'ERROR_REPORT_EMAIL': 'dummy@example.com',
+        }
+    )
+    def test_sent_kafka_failure_email_with_email_already_sent(self, cache_mock, logger_mock):
+        """
+        Test that kafka failure email is not sent if it is already sent.
+        """
+        sent_kafka_failure_email('Dummy Error')
+        self.assertTrue(cache_mock.called)
+        logger_mock.info.assert_called_with('Email Already Sent: Events delivery failure report'
+                                            ' has been already sent to dummy@example.com.')
+
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.LOGGER',
+        autospec=True,
+    )
     @mock.patch(
         'openedx_caliper_tracking.tasks.send_notification',
-        autospec=True
-    )
-    @mock.patch(
-        'openedx_caliper_tracking.tasks.KafkaProducer',
+        autospec=True,
+        return_value=False
     )
     @override_settings(
         CALIPER_KAFKA_SETTINGS={
-            'END_POINT': 'http://localhost:9092',
-            'TOPIC_NAME': 'dummy topic',
             'ERROR_REPORT_EMAIL': 'dummy@example.com',
-            'MAXIMUM_RETRIES': 3
-        },
-        FEATURES={'ENABLE_KAFKA_FOR_CALIPER': True}
+        }
     )
-    def test_caliper_event_delivery_failure_email_sent_if_host_not_found(self, producer_mock, send_email_mock):
+    def test_sent_kafka_failure_email_with_failure(self, send_notification_mock, logger_mock):
         """
-        Test that in case of host not found error delivery failure report email is sent.
+        Test that if sending kafka failure email is failed an error message is logged.
         """
-        producer_mock.side_effect = _host_not_found(KafkaError.__class__.__name__, {}, {})
-        CaliperProcessor().__call__(self.event)
-        self.assertTrue(producer_mock.called)
-        self.assertTrue(send_email_mock.called)
+        sent_kafka_failure_email('Dummy Error')
+        self.assertTrue(send_notification_mock.called)
+        logger_mock.error.assert_called_with('Email Sending Failed: Could not send events delivery'
+                                             ' failure report to dummy@example.com.')
 
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.LOGGER',
+        autospec=True,
+    )
     @mock.patch(
         'openedx_caliper_tracking.tasks.send_notification',
-        return_value=0,
-        autospec=True
-    )
-    @mock.patch(
-        'openedx_caliper_tracking.tasks.KafkaProducer',
+        autospec=True,
+        return_value=True
     )
     @override_settings(
         CALIPER_KAFKA_SETTINGS={
-            'END_POINT': 'http://localhost:9092',
-            'TOPIC_NAME': 'dummy topic',
             'ERROR_REPORT_EMAIL': 'dummy@example.com',
-            'MAXIMUM_RETRIES': 3
-        },
-        FEATURES={'ENABLE_KAFKA_FOR_CALIPER': True}
+        }
     )
-    def test_caliper_event_delivery_failure_email_not_sent_if_host_not_found(self, producer_mock, send_email_mock):
-        """
-        Test delivery failure report email failure in case of host not found.
-        """
-        producer_mock.side_effect = _host_not_found(KafkaError.__class__.__name__, {}, {})
-        CaliperProcessor().__call__(self.event)
-        self.assertTrue(producer_mock.called)
-        self.assertTrue(send_email_mock.called)
+    def test_send_system_recovery_email_with_success(self, send_notification_mock, logger_mock):
+        send_system_recovery_email()
+        self.assertTrue(send_notification_mock.called)
+        logger_mock.info.assert_called_with('Email Sent Successfully: Events delivery success report sent to '
+                                            'dummy@example.com.')
 
     @mock.patch(
-        'openedx_caliper_tracking.tasks.deliver_caliper_event_to_kafka'
+        'openedx_caliper_tracking.tasks.LOGGER',
+        autospec=True,
+    )
+    @mock.patch(
+        'openedx_caliper_tracking.tasks.send_notification',
+        autospec=True,
+        return_value=False
     )
     @override_settings(
         CALIPER_KAFKA_SETTINGS={
-            'END_POINT': 'http://localhost:9092',
-            'TOPIC_NAME': 'dummy topic',
             'ERROR_REPORT_EMAIL': 'dummy@example.com',
-            'MAXIMUM_RETRIES': 3
-        },
-        FEATURES={'ENABLE_KAFKA_FOR_CALIPER': False}
+        }
     )
-    def test_caliper_event_is_not_delivered_if_flag_is_disable(self, delivery_mock):
+    def test_send_system_recovery_email_with_failure(self, send_notification_mock, logger_mock):
         """
-        Test events should not be delivered if feature flag ENABLE_KAFKA_FOR_CALIPER is disable.
+        Test that if sending kafka failure email is failed an error message is logged.
         """
-        CaliperProcessor().__call__(self.event)
-        self.assertFalse(delivery_mock.called)
-
-    @mock.patch(
-        'openedx_caliper_tracking.tasks.deliver_caliper_event_to_kafka'
-    )
-    @override_settings(
-        FEATURES={'ENABLE_KAFKA_FOR_CALIPER': True}
-    )
-    def test_caliper_event_is_not_delivered_if_flag_is_enable_but_settings_not_given(self, delivery_mock):
-        """
-        Test events should not be delivered if feature flag ENABLE_KAFKA_FOR_CALIPER is disable
-        but CALIPER_KAFKA_SETTINGS are not given.
-        """
-        if hasattr(settings, 'CALIPER_KAFKA_SETTINGS'):
-            del settings.CALIPER_KAFKA_SETTINGS
-
-        CaliperProcessor().__call__(self.event)
-        self.assertFalse(delivery_mock.called)
+        send_system_recovery_email()
+        self.assertTrue(send_notification_mock.called)
+        logger_mock.error.assert_called_with('Email Sending Failed: Could not send events delivery success report to '
+                                             'dummy@example.com.')

--- a/openedx_caliper_tracking/tests/test_caliper_transformers.py
+++ b/openedx_caliper_tracking/tests/test_caliper_transformers.py
@@ -35,6 +35,21 @@ class CaliperTransformationTestCase(TestCase):
         ),
         autospec=True
     )
+    @mock.patch(
+        'openedx_caliper_tracking.transformers.cohort_transformers.reverse',
+        return_value='/u/honor',
+        autospec=True
+    )
+    @mock.patch(
+        'openedx_caliper_tracking.transformers.certificate_transformers.get_certificate_url',
+        return_value='http://localhost:18000/certificates/user/8/course/course-v1:edx+cs-101+2018',
+        autospec=True
+    )
+    @mock.patch(
+        'openedx_caliper_tracking.transformers.enrollment_transformers.reverse',
+        return_value='/courses/course-v1:edx+cs-101+2018/about',
+        autospec=True
+    )
     def test_caliper_transformers(self, *args):
         """
         Tests whether all the caliper transformers are working as expected

--- a/openedx_caliper_tracking/tests/test_requirements.txt
+++ b/openedx_caliper_tracking/tests/test_requirements.txt
@@ -1,0 +1,8 @@
+celery==4.3.0
+Django==1.11.21
+isodate==0.6.0
+mock==3.0.5
+python-dateutil==2.8.0
+requests==2.22.0
+coverage
+factory-boy==2.12.0

--- a/openedx_caliper_tracking/tests/test_utils.py
+++ b/openedx_caliper_tracking/tests/test_utils.py
@@ -1,0 +1,118 @@
+from smtplib import SMTPException
+
+import mock
+from django.test import TestCase, override_settings
+
+from openedx_caliper_tracking import utils
+from openedx_caliper_tracking.tests.factories import UserFactory
+
+
+class CaliperUtilsTestCase(TestCase):
+
+    def test_convert_date_time(self):
+        self.assertEquals('2018-10-16T14:23:24.785Z', utils.convert_datetime('2018-10-16T14:23:24.785148+00:00'))
+
+    def test_get_username_from_user_id(self):
+        user = UserFactory(username='dummy')
+        self.assertEquals('dummy', utils.get_username_from_user_id(user.id))
+
+    @mock.patch(
+        'openedx_caliper_tracking.utils.reverse',
+        autospec=True,
+        return_value='/u/dummy'
+    )
+    @override_settings(
+        LMS_ROOT_URL='https://localhost:18000'
+    )
+    def test_get_user_link_from_username_without_reverse_not_found_exception(self, reverse_mock):
+        formatted_link = utils.get_user_link_from_username('dummy')
+        reverse_mock.assert_called_with('learner_profile', kwargs={'username': 'dummy'})
+        self.assertEquals('https://localhost:18000/u/dummy', formatted_link)
+
+    @override_settings(
+        LMS_ROOT_URL='https://localhost:18000'
+    )
+    def test_get_user_link_from_username_with_reverse_not_found_exception(self):
+        formatted_link = utils.get_user_link_from_username('dummy')
+        self.assertEquals('https://localhost:18000/u/dummy', formatted_link)
+
+    def test_get_topic_id_from_team_id(self):
+        team_mock = mock.MagicMock()
+        with mock.patch.dict('sys.modules', **{
+                             'lms': team_mock,
+                             'lms.djangoapps': team_mock,
+                             'lms.djangoapps.teams': team_mock,
+                             'lms.djangoapps.teams.models': team_mock,
+                             }):
+            utils.get_topic_id_from_team_id(1)
+        self.assertEquals(str(team_mock.mock_calls), '[call.CourseTeam.objects.get(team_id=1)]')
+
+    @mock.patch(
+        'openedx_caliper_tracking.utils.get_topic_id_from_team_id',
+        autospec=True,
+        return_value=1
+    )
+    def test_get_team_url_from_team_id(self, get_topic_id_mock):
+        team_url = utils.get_team_url_from_team_id('http://localhost:18000/courses/dummy-course-id/teams/', 1)
+        get_topic_id_mock.assert_called_with(1)
+        self.assertEquals('http://localhost:18000/courses/dummy-course-id/teams/#teams/1/1', team_url)
+
+    @mock.patch(
+        'openedx_caliper_tracking.utils.reverse',
+        autospec=True,
+        return_value='/certificates/user/8/course/dummy-course-id',
+    )
+    @override_settings(
+        LMS_ROOT_URL='https://localhost:18000'
+    )
+    def test_get_certificate_url(self, reverse_mock):
+        certificate_uri = utils.get_certificate_url(8, 'dummy-course-id')
+        self.assertEquals('https://localhost:18000/certificates/user/8/course/dummy-course-id', certificate_uri)
+        reverse_mock.assert_called_with('certificates:html_view', kwargs={'user_id': 8, 'course_id': 'dummy-course-id'})
+
+    @mock.patch(
+        'openedx_caliper_tracking.utils.log',
+        autospec=True,
+    )
+    @mock.patch(
+        'openedx_caliper_tracking.utils.send_mail',
+        autospec=True,
+        return_value=1
+    )
+    def test_send_notification_success(self, mail_send_mock, logger_mock):
+        data = {
+            'name': 'Dummy Support',
+            'body': 'Below is the additional information regarding failure:',
+            'error': 'dummy error'
+        }
+        subject = 'Dummy Subject'
+
+        utils.send_notification(data, subject, 'dummy_sender@example.com', ['dummy_receiver@example.com'])
+        self.assertTrue(mail_send_mock.called)
+        logger_mock.info.assert_called_with('Email has been sent from "dummy_sender@example.com" to '
+                                            '"[\'dummy_receiver@example.com\']" for content "{\'body'
+                                            '\': \'Below is the additional information regarding '
+                                            'failure:\', \'name\': \'Dummy Support\', \'error\': \'dummy error\'}".')
+
+    @mock.patch(
+        'openedx_caliper_tracking.utils.log',
+        autospec=True,
+    )
+    @mock.patch(
+        'openedx_caliper_tracking.utils.send_mail',
+        autospec=True,
+        side_effect=SMTPException
+    )
+    def test_send_notification_failure(self, mail_send_mock, logger_mock):
+        data = {
+            'name': 'Dummy Support',
+            'body': 'Below is the additional information regarding failure:',
+            'error': 'dummy error'
+        }
+        subject = 'Dummy Subject'
+        utils.send_notification(data, subject, 'dummy_sender@example.com', ['dummy_receiver@example.com'])
+        self.assertTrue(mail_send_mock.called)
+        logger_mock.exception.assert_called_with('Unable to send an email from "dummy_sender@example.com" to '
+                                                 '"[\'dummy_receiver@example.com\']" for content "{\'body\': '
+                                                 '\'Below is the additional information regarding failure:\','
+                                                 ' \'name\': \'Dummy Support\', \'error\': \'dummy error\'}".')

--- a/openedx_caliper_tracking/tests/testing_backend.py
+++ b/openedx_caliper_tracking/tests/testing_backend.py
@@ -1,0 +1,22 @@
+"""
+Testing Event tracking backend module.
+"""
+
+from __future__ import absolute_import
+
+import abc
+
+
+class BaseBackend(object):
+    """
+    Abstract Base Class for testing event tracking backends.
+    """
+    __metaclass__ = abc.ABCMeta
+
+    def __init__(self, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def send(self, event):
+        """Send event to tracker."""
+        pass

--- a/openedx_caliper_tracking/utils.py
+++ b/openedx_caliper_tracking/utils.py
@@ -1,7 +1,6 @@
 """
 Utils required in transformers
 """
-import json
 import logging
 from smtplib import SMTPException
 
@@ -11,7 +10,6 @@ from django.conf import settings
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
 from django.urls.exceptions import NoReverseMatch
-from django.template.loader import get_template
 
 log = logging.getLogger(__name__)
 UTC_DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%f'
@@ -128,18 +126,14 @@ def send_notification(data, subject, from_email, dest_emails):
         if data.get('error'):
             message = message + '\n\nError:\t{}'.format(data.get('error'))
         response = send_mail(subject, message, from_email, dest_emails)
-        log.info(
-            'Email has been sent from "{}" to "{}" for content "{}".'.format(
-            from_email,
-            dest_emails,
-            data
-        ))
+        log.info('Email has been sent from "{}" to "{}" for content "{}".'.format(
+                 from_email,
+                 dest_emails,
+                 data))
         return response
     except SMTPException:
-        log.exception(
-            'Unable to send an email from "{}" to "{}" for content "{}".'.format(
-            from_email,
-            dest_emails,
-            data
-        ))
+        log.exception('Unable to send an email from "{}" to "{}" for content "{}".'.format(
+                      from_email,
+                      dest_emails,
+                      data))
         return False


### PR DESCRIPTION
#### Story Link
[https://edlyio.atlassian.net/browse/EDS-69](https://edlyio.atlassian.net/browse/EDS-69)

#### PR Description

This PR is to make the caliper tests independent. Moreover, a few new tests were also added to increase the code coverage.
Some `Current` and `Expected JSON` files are modified to sync the test settings for all the tests related to transformation.

#### Type of change

Please select the options that are relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Change

#### How to test?

- Clone this repo
```
git clone git@github.com:ucsd-ets/openedx-caliper-tracking.git
```
- Switch to `umar/make-caliper-tests-independent` git branch
- After that run the following command at the same path in which you have cloned the repo
```
sudo ./openedx-caliper-tracking/openedx_caliper_tracking/tests/local_test_script.sh
```


#### Checklist before merging:

- [ ] Squased
- [ ] Reviewd
