### PR TITLE
add retry for generic exception

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ Installation
 To install **openedx-caliper-tracking** in your Open edX instance, please add the following line to your ``requirements file``. (For most Open edX installations it should be located at ``edx-platform/requirements/edx/base.txt``).
 ::
 
-    openedx-caliper-tracking==0.14.1
+    openedx-caliper-tracking==0.14.2
 
 For manual installation:
 ::

--- a/openedx_caliper_tracking/kafka_utils.py
+++ b/openedx_caliper_tracking/kafka_utils.py
@@ -17,3 +17,4 @@ def get_kafka_producer_configurations():
 
     except AttributeError as ex:
         LOGGER.exception('Invalid or no configurations are provided for KafkaProducer: %s', str(ex))
+        raise

--- a/openedx_caliper_tracking/tests/test_caliper_kafka.py
+++ b/openedx_caliper_tracking/tests/test_caliper_kafka.py
@@ -22,7 +22,7 @@ CALIPER_KAFKA_SETTINGS_FIXTURE = {
         ]
     },
     'TOPIC_NAME': 'dummy topic',
-    'ERROR_REPORT_EMAILS': ['dummy@example.com',],
+    'ERROR_REPORT_EMAILS': ['dummy@example.com', ],
     'MAXIMUM_RETRIES': 3
 }
 
@@ -180,41 +180,10 @@ class CaliperKafkaTestCase(TestCase):
         """
         deliver_caliper_event_to_kafka({}, 'book')
         self.assertTrue(producer_mock.called)
-        self.assertTrue(sent_email_mock.called)
-        logger_mock.error.assert_called_with('Logs Delivery Failed: Could not deliver event (book) to kafka'
-                                             ' ([\'testing.com\']) due to the error:'
-                                             ' Invalid Configurations are provided')
-        self.assertFalse(retry_mock.called)
-
-    @mock.patch(
-        'openedx_caliper_tracking.tasks.LOGGER',
-        autospec=True,
-    )
-    @mock.patch(
-        'openedx_caliper_tracking.tasks.sent_kafka_failure_email.delay',
-        autospec=True
-    )
-    @mock.patch(
-        'openedx_caliper_tracking.tasks.KafkaProducer',
-        autospec=True,
-        side_effect=KafkaError
-    )
-    @override_settings(
-        CALIPER_KAFKA_SETTINGS=CALIPER_KAFKA_SETTINGS_FIXTURE,
-        CALIPER_KAFKA_AUTH_SETTINGS=CALIPER_KAFKA_AUTH_SETTINGS_FIXTURE
-    )
-    def test_deliver_caliper_event_to_kafka_without_celery_with_error_without_retry(self, producer_mock,
-                                                                                    sent_email_mock, logger_mock):
-        """
-        Test that caliper event is not delivered to kafka when error is occurred
-        and at last retry failure email task is called.
-        """
-        deliver_caliper_event_to_kafka({}, 'book')
-        self.assertTrue(producer_mock.called)
-        self.assertTrue(sent_email_mock.called)
-        logger_mock.error.assert_called_with('Logs Delivery Failed: Could not deliver event (book) to kafka'
-                                             ' ([\'testing.com\']) due to the error:'
-                                             ' Invalid Configurations are provided')
+        self.assertTrue(retry_mock.called)
+        self.assertFalse(sent_email_mock.called)
+        logger_mock.error.assert_called_with(('Logs Delivery Failed: Could not deliver event (book) to kafka'
+                                              ' ([\'testing.com\']) because of KafkaError.'))
 
     @mock.patch(
         'openedx_caliper_tracking.tasks.sent_kafka_failure_email.delay',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name='openedx-caliper-tracking',
-    version='0.14.1',
+    version='0.14.2',
     packages=find_packages(),
     include_package_data=True,
     license='GPL 3.0',


### PR DESCRIPTION
### Story Link
https://edlyio.atlassian.net/browse/EDE-736

#### PR Description

Remove the generic except block so that in case of `KafkaError` while initializing the producer, task will be retried.
